### PR TITLE
Resolve #165, #173, #178, #179, #182, #183, #187, #188, #191

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,4 @@ REACT_APP_INFURA_API_KEY=
 REACT_APP_BTC_NETWORK=testnet
 REACT_APP_LEDGER_API_URL=https://api.ledgerwallet.com/blockchain/v2/btc_testnet
 REACT_APP_BLOCKCYPHER_API_URL=https://api.blockcypher.com/v1/btc/test3
+REACT_APP_DAI_ADDRESS=

--- a/.env
+++ b/.env
@@ -1,2 +1,8 @@
+REACT_APP_GOOGLE_CLIENT_ID=
+REACT_APP_GOOGLE_API_SCOPE=https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata
+REACT_APP_GOOGLE_API_DISCOVERY_DOCS=https://www.googleapis.com/discovery/v1/apis/drive/v3/rest
 REACT_APP_NETWORK_NAME=rinkeby
 REACT_APP_INFURA_API_KEY=
+REACT_APP_BTC_NETWORK=testnet
+REACT_APP_LEDGER_API_URL=https://api.ledgerwallet.com/blockchain/v2/btc_testnet
+REACT_APP_BLOCKCYPHER_API_URL=https://api.blockcypher.com/v1/btc/test3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1041,11 +1041,6 @@
         "react-is": "^16.6.3"
       }
     },
-    "@mattiasbuelens/web-streams-polyfill": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@mattiasbuelens/web-streams-polyfill/-/web-streams-polyfill-0.3.1.tgz",
-      "integrity": "sha512-IW+tCurEH2NL2tA3KKFAMXa90WWmTJMZksnQWMABe3bMijV7hEiOLthy4tKGTnUTV8qVf8WTCApiGmKb75Bxkg=="
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1364,14 +1359,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
-    },
-    "address-rfc2822": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/address-rfc2822/-/address-rfc2822-2.0.4.tgz",
-      "integrity": "sha1-Lb07jWwt4elXwahUncAS1Au8NDE=",
-      "requires": {
-        "email-addresses": "^3.0.0"
-      }
     },
     "aes-js": {
       "version": "3.0.0",
@@ -1813,10 +1800,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asmcrypto.js": {
-      "version": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83",
-      "from": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83"
     },
     "asn1": {
       "version": "0.2.4",
@@ -3041,6 +3024,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
+    "bigi": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
+      "integrity": "sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU="
+    },
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -3065,6 +3053,27 @@
         "tiny-secp256k1": "^1.0.0",
         "typeforce": "^1.11.5",
         "wif": "^2.0.6"
+      }
+    },
+    "bip38": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bip38/-/bip38-2.0.2.tgz",
+      "integrity": "sha512-22KDak0RDyghFbR0Si7wyq9IgY423YzGYzWLpGeofH3DaolOQqjD3mNN08eFoubKlbyclOQKFwtONMv2SD9V3A==",
+      "requires": {
+        "bigi": "^1.2.0",
+        "browserify-aes": "^1.0.1",
+        "bs58check": "<3.0.0",
+        "buffer-xor": "^1.0.2",
+        "create-hash": "^1.1.1",
+        "ecurve": "^1.0.0",
+        "scryptsy": "^2.0.0"
+      },
+      "dependencies": {
+        "scryptsy": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.0.0.tgz",
+          "integrity": "sha1-Jiw28CMc+nZU4jY/o5TNLexm83g="
+        }
       }
     },
     "bip66": {
@@ -5070,6 +5079,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "ecurve": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
+      "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
+      "requires": {
+        "bigi": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5093,11 +5111,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
-    },
-    "email-addresses": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
-      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg=="
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -10700,26 +10713,6 @@
         }
       }
     },
-    "node-localstorage": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
-      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
-      "requires": {
-        "write-file-atomic": "^1.1.4"
-      },
-      "dependencies": {
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
-          }
-        }
-      }
-    },
     "node-notifier": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
@@ -13992,80 +13985,6 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "openpgp": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-4.4.10.tgz",
-      "integrity": "sha512-OdDK5+tVApsVFMmrbzVtLKlZHWOjy5LDQCbVOkun9jMXNhaJ+eX6DArN6BpPs+liVztqBzCqmTKgZ+tvmUNtqg==",
-      "requires": {
-        "@mattiasbuelens/web-streams-polyfill": "^0.3.1",
-        "address-rfc2822": "^2.0.3",
-        "asmcrypto.js": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83",
-        "asn1.js": "^5.0.0",
-        "bn.js": "^4.11.8",
-        "buffer": "^5.0.8",
-        "elliptic": "github:openpgpjs/elliptic#ad81845f693effa5b4b6d07db2e82112de222f48",
-        "hash.js": "^1.1.3",
-        "node-fetch": "^2.1.2",
-        "node-localstorage": "~1.3.0",
-        "pako": "^1.0.6",
-        "seek-bzip": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
-        "web-stream-tools": "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc"
-      },
-      "dependencies": {
-        "asn1.js": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
-          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
-          "requires": {
-            "bn.js": "^4.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "elliptic": {
-          "version": "github:openpgpjs/elliptic#ad81845f693effa5b4b6d07db2e82112de222f48",
-          "from": "github:openpgpjs/elliptic#ad81845f693effa5b4b6d07db2e82112de222f48",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
-        "node-fetch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
-        },
-        "seek-bzip": {
-          "version": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
-          "from": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
-          "requires": {
-            "commander": "~2.8.1"
-          }
-        }
       }
     },
     "opn": {
@@ -18406,11 +18325,6 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -20033,10 +19947,6 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "web-stream-tools": {
-      "version": "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc",
-      "from": "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc"
     },
     "web3": {
       "version": "1.0.0-beta.37",

--- a/package-lock.json
+++ b/package-lock.json
@@ -903,6 +903,45 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-4.39.0.tgz",
       "integrity": "sha512-kBr2rnoYDACRCxTLtEufE4oCvYj6vx2oFWVVjwskBxYsF5LC9R8Mbg5C4GgvDweiWW4Io8HA9p9jCsOfdCDygg=="
     },
+    "@ledgerhq/hw-app-btc": {
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-btc/-/hw-app-btc-4.41.1.tgz",
+      "integrity": "sha512-uFxY3D/WdYpJRX2uaunW05+gU/GMjO5vR+S6Y3pfimsNIRGG6ihyJTp6t7KfkChEbRw9eIKFhJwGkCli9um8qA==",
+      "requires": {
+        "@ledgerhq/hw-transport": "^4.41.1",
+        "create-hash": "^1.1.3"
+      },
+      "dependencies": {
+        "@ledgerhq/devices": {
+          "version": "4.41.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-4.41.1.tgz",
+          "integrity": "sha512-8WDj38iR1Fow2JoEG9w8rJouJcXXObw3KeTrh3fUzZ0qap4o8Q3HIc8i1Hr6XGxAjX64YmtebTJil3HjiNNMtQ==",
+          "requires": {
+            "@ledgerhq/errors": "^4.41.1"
+          }
+        },
+        "@ledgerhq/errors": {
+          "version": "4.41.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-4.41.1.tgz",
+          "integrity": "sha512-MKYzYNT5AKKZu2Ss0QrMXUS7Zri1F0HpNI3yKGjnhXEVxtr2fvxFXKgqdw7sdo+cLtkbNTJhiclemt0e0HtL0Q=="
+        },
+        "@ledgerhq/hw-transport": {
+          "version": "4.41.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.41.1.tgz",
+          "integrity": "sha512-0Q4djKCebQ0EAtkrYtD5vN7az580RY0LG3hzDwUabN8EqLWdSJElgB6OfYJk+wHUZAnVNFwXKRZ15cCFdbXExw==",
+          "requires": {
+            "@ledgerhq/devices": "^4.41.1",
+            "@ledgerhq/errors": "^4.41.1",
+            "events": "^3.0.0"
+          }
+        },
+        "events": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+          "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+        }
+      }
+    },
     "@ledgerhq/hw-app-eth": {
       "version": "4.39.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-4.39.0.tgz",
@@ -1001,6 +1040,11 @@
         "prop-types": "^15.6.0",
         "react-is": "^16.6.3"
       }
+    },
+    "@mattiasbuelens/web-streams-polyfill": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mattiasbuelens/web-streams-polyfill/-/web-streams-polyfill-0.3.1.tgz",
+      "integrity": "sha512-IW+tCurEH2NL2tA3KKFAMXa90WWmTJMZksnQWMABe3bMijV7hEiOLthy4tKGTnUTV8qVf8WTCApiGmKb75Bxkg=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -1320,6 +1364,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+    },
+    "address-rfc2822": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/address-rfc2822/-/address-rfc2822-2.0.4.tgz",
+      "integrity": "sha1-Lb07jWwt4elXwahUncAS1Au8NDE=",
+      "requires": {
+        "email-addresses": "^3.0.0"
+      }
     },
     "aes-js": {
       "version": "3.0.0",
@@ -1761,6 +1813,10 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asmcrypto.js": {
+      "version": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83",
+      "from": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83"
     },
     "asn1": {
       "version": "0.2.4",
@@ -2938,6 +2994,14 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
+      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -2955,6 +3019,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bech32": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
+      "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
     },
     "bfj": {
       "version": "6.1.1",
@@ -2985,12 +3054,86 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bip32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.2.tgz",
+      "integrity": "sha512-kedLYj8yvYzND+EfzeoMSlGiN7ImiRBF/MClJSZPkMfcU+OQO7ZpL5L/Yg+TunebBZIHhunstiQF//KLKSF5rg==",
+      "requires": {
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      }
+    },
     "bip66": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+    },
+    "bitcoinjs-lib": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.3.tgz",
+      "integrity": "sha512-cb5t55MYUpwQi095J+u6eyltgIU7lbhZfC6+annstncDhfH4cyctW5jmU/tac7NonZZFYH7DktWnDxUm9AWWDQ==",
+      "requires": {
+        "bech32": "^1.1.2",
+        "bip32": "^1.0.0",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.1",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      }
+    },
+    "bitcore-lib": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.1.0.tgz",
+      "integrity": "sha512-7aQYgduwnCYRXY7FHTQIVnDwY/5s112kwUzXWy6Yg88CVo5oUKsYfOqy9ESh/zFnOwKEXTc1NMRB87K1xhoF9w==",
+      "requires": {
+        "bn.js": "=4.11.8",
+        "bs58": "^4.0.1",
+        "buffer-compare": "=1.1.1",
+        "elliptic": "=6.4.0",
+        "inherits": "=2.0.1",
+        "lodash": "=4.17.11"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+          "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
       }
     },
     "bl": {
@@ -3211,6 +3354,24 @@
         "node-releases": "^1.1.3"
       }
     },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -3242,6 +3403,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-compare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.1.1.tgz",
+      "integrity": "sha1-W+e+hTr4kZjR9N3AkNHWakiu9ZY="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -4927,6 +5093,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
+    },
+    "email-addresses": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
+      "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg=="
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -10155,6 +10326,11 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
     },
+    "merkle-lib": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
+      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -10521,6 +10697,26 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "node-localstorage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "requires": {
+        "write-file-atomic": "^1.1.4"
+      },
+      "dependencies": {
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
         }
       }
     },
@@ -13798,6 +13994,80 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "openpgp": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-4.4.10.tgz",
+      "integrity": "sha512-OdDK5+tVApsVFMmrbzVtLKlZHWOjy5LDQCbVOkun9jMXNhaJ+eX6DArN6BpPs+liVztqBzCqmTKgZ+tvmUNtqg==",
+      "requires": {
+        "@mattiasbuelens/web-streams-polyfill": "^0.3.1",
+        "address-rfc2822": "^2.0.3",
+        "asmcrypto.js": "github:openpgpjs/asmcrypto#6e4e407b9b8ae317925a9e677cc7b4de3e447e83",
+        "asn1.js": "^5.0.0",
+        "bn.js": "^4.11.8",
+        "buffer": "^5.0.8",
+        "elliptic": "github:openpgpjs/elliptic#ad81845f693effa5b4b6d07db2e82112de222f48",
+        "hash.js": "^1.1.3",
+        "node-fetch": "^2.1.2",
+        "node-localstorage": "~1.3.0",
+        "pako": "^1.0.6",
+        "seek-bzip": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
+        "web-stream-tools": "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+          "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "elliptic": {
+          "version": "github:openpgpjs/elliptic#ad81845f693effa5b4b6d07db2e82112de222f48",
+          "from": "github:openpgpjs/elliptic#ad81845f693effa5b4b6d07db2e82112de222f48",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+        },
+        "seek-bzip": {
+          "version": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
+          "from": "github:openpgpjs/seek-bzip#3aca608ffedc055a1da1d898ecb244804ef32209",
+          "requires": {
+            "commander": "~2.8.1"
+          }
+        }
+      }
+    },
     "opn": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
@@ -16101,6 +16371,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+      "requires": {
+        "bitcoin-ops": "^1.3.0"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -18128,6 +18406,11 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -19007,6 +19290,18 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-secp256k1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.0.1.tgz",
+      "integrity": "sha512-Wz2kMPWtCI5XBftFeF3bUL8uz2+VlasniKwOkRPjvL7h1QVd9rbhrve/HWUu747kJKzVf1XHonzcdM4Ut8fvww==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.10.0"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -19184,10 +19479,23 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typeface-roboto": {
       "version": "0.0.54",
       "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-0.0.54.tgz",
       "integrity": "sha512-sOFA1FXgP0gOgBYlS6irwq6hHYA370KE3dPlgYEJHL3PJd5X8gQE0RmL79ONif6fL5JZuGDj+rtOrFeOqz5IZQ=="
+    },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "u2f-api": {
       "version": "0.2.7",
@@ -19629,6 +19937,14 @@
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
       "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
+    "varuint-bitcoin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
+      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -19717,6 +20033,10 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "web-stream-tools": {
+      "version": "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc",
+      "from": "github:openpgpjs/web-stream-tools#84a497715c9df271a673f8616318264ab42ab3cc"
     },
     "web3": {
       "version": "1.0.0-beta.37",
@@ -19999,7 +20319,9 @@
           "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "requires": {
             "debug": "^2.2.0",
-            "nan": "^2.3.3"
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
           }
         }
       }
@@ -20672,6 +20994,14 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -20979,6 +21309,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.7.2",
     "@fortawesome/free-solid-svg-icons": "^5.7.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
+    "@ledgerhq/hw-app-btc": "^4.41.1",
     "@ledgerhq/hw-app-eth": "^4.39.0",
     "@ledgerhq/hw-transport-u2f": "^4.39.0",
     "@material-ui/core": "^3.9.2",
@@ -16,6 +17,8 @@
     "axios": "^0.19.0-beta.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
+    "bitcoinjs-lib": "^4.0.3",
+    "bitcore-lib": "^8.1.0",
     "bn.js": "^4.11.8",
     "connected-react-router": "^6.3.1",
     "dotenv-webpack": "^1.7.0",
@@ -29,6 +32,7 @@
     "moment": "^2.24.0",
     "npm": "^6.8.0",
     "numeral": "^2.0.6",
+    "openpgp": "^4.4.10",
     "query-string": "^6.2.0",
     "randombytes": "^2.0.6",
     "react": "^16.8.2",
@@ -52,7 +56,7 @@
     "web3": "^1.0.0-beta.37"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "cp ./node_modules/openpgp/dist/openpgp.* ./public/openpgp/ && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.19.0-beta.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
+    "bip38": "^2.0.2",
     "bitcoinjs-lib": "^4.0.3",
     "bitcore-lib": "^8.1.0",
     "bn.js": "^4.11.8",
@@ -32,7 +33,6 @@
     "moment": "^2.24.0",
     "npm": "^6.8.0",
     "numeral": "^2.0.6",
-    "openpgp": "^4.4.10",
     "query-string": "^6.2.0",
     "randombytes": "^2.0.6",
     "react": "^16.8.2",
@@ -53,10 +53,11 @@
     "typeface-roboto": "0.0.54",
     "uuid": "^3.3.2",
     "validator": "^10.11.0",
-    "web3": "^1.0.0-beta.37"
+    "web3": "^1.0.0-beta.37",
+    "wif": "^2.0.6"
   },
   "scripts": {
-    "start": "cp ./node_modules/openpgp/dist/openpgp.* ./public/openpgp/ && react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/ERC20.js
+++ b/src/ERC20.js
@@ -27,7 +27,7 @@ async function getTransferTxObj (from, to, transferAmount, cryptoType) {
 async function getGasPriceGivenBalance (address, gas) {
   let web3 = new Web3(new Web3.providers.HttpProvider(infuraApi))
   let balance = new BN(await web3.eth.getBalance(address))
-  return balance.div(new BN(gas))
+  return balance.div(new BN(gas)).toString()
 }
 
 export default { getBalance, getTransferTxObj, getGasPriceGivenBalance }

--- a/src/actions/walletActions.js
+++ b/src/actions/walletActions.js
@@ -49,8 +49,8 @@ async function _checkMetamaskConnection (cryptoType, dispatch) {
   return rv
 }
 
-async function _checkLedgerNanoSConnection () {
-  const deviceConnected = await ledgerNanoS.deviceConnected()
+async function _checkLedgerNanoSConnection (cryptoType) {
+  const deviceConnected = await ledgerNanoS.deviceConnected(cryptoType)
   if (deviceConnected === null) {
     const msg = 'Ledger not connected'
     throw msg
@@ -89,10 +89,10 @@ function onMetamaskAccountsChanged (accounts) {
   }
 }
 
-function checkLedgerNanoSConnection () {
+function checkLedgerNanoSConnection (cryptoType) {
   return {
     type: 'CHECK_LEDGER_NANOS_CONNECTION',
-    payload: _checkLedgerNanoSConnection()
+    payload: _checkLedgerNanoSConnection(cryptoType)
   }
 }
 

--- a/src/components/CancelReceiptComponent.jsx
+++ b/src/components/CancelReceiptComponent.jsx
@@ -16,7 +16,7 @@ import { getCryptoSymbol } from '../tokens'
 
 class CancelReceiptComponent extends Component {
   render () {
-    const { classes, receipt, gasCost } = this.props
+    const { classes, receipt, txCost } = this.props
     const { sendingId, transferAmount, cryptoType, cancelTimestamp, cancelTxHash } = receipt
     return (
       <Grid container direction='column' justify='center' alignItems='center'>
@@ -45,10 +45,10 @@ class CancelReceiptComponent extends Component {
                 </Grid>
                 <Grid item className={classes.reviewItem}>
                   <Typography className={classes.reviewSubtitle} align='left'>
-                    Gas Fee
+                    Transaction Fee
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {`${gasCost.costInEther} ETH`}
+                    {`${txCost.costInStandardUnit} ${getCryptoSymbol(cryptoType)}`}
                   </Typography>
                 </Grid>
                 <Grid item className={classes.reviewItem}>
@@ -56,7 +56,7 @@ class CancelReceiptComponent extends Component {
                     You will receive*
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {`${parseFloat(transferAmount) - parseFloat(gasCost.costInEther)} ETH`}
+                    {`${parseFloat(transferAmount) - parseFloat(txCost.costInStandardUnit)} ${getCryptoSymbol(cryptoType)}`}
                   </Typography>
                 </Grid>
                 <Grid item className={classes.reviewItem}>

--- a/src/components/CancelReviewComponent.jsx
+++ b/src/components/CancelReviewComponent.jsx
@@ -18,13 +18,13 @@ class CancelReviewComponent extends Component {
 
   componentDidUpdate (prevProps) {
     const { open } = this.state
-    const { transfer, escrowWallet, gasCost, receipt, actionsPending } = this.props
+    const { transfer, escrowWallet, txCost, receipt, actionsPending } = this.props
     if (transfer) {
       const { sendingId, sendTxHash, transferAmount, cryptoType } = transfer
       if (!actionsPending.cancelTransfer && // cancelTransfer is not currently running
-          !receipt && // cancelTransfer has not been called
-          open && // cancel popup is currently focused
-          escrowWallet.decryptedWallet) { // escrowWallet has been decrypted
+        !receipt && // cancelTransfer has not been called
+        open && // cancel popup is currently focused
+        escrowWallet.decryptedWallet) { // escrowWallet has been decrypted
         // submit cancelTransfer action
         this.props.cancelTransfer({
           escrowWallet: escrowWallet.decryptedWallet,
@@ -32,7 +32,7 @@ class CancelReviewComponent extends Component {
           sendTxHash: sendTxHash,
           cryptoType: cryptoType,
           transferAmount: transferAmount,
-          gasCost: gasCost
+          txCost: txCost
         })
       }
     }
@@ -103,11 +103,11 @@ class CancelReviewComponent extends Component {
                     Cancel Transfer
                   </Button>
                   {(actionsPending.verifyPassword || actionsPending.cancelTransfer) &&
-                  <CircularProgress
-                    size={24}
-                    color='primary'
-                    className={classes.buttonProgress}
-                  />}
+                    <CircularProgress
+                      size={24}
+                      color='primary'
+                      className={classes.buttonProgress}
+                    />}
                 </div>
               </Grid>
             </Grid>
@@ -118,7 +118,7 @@ class CancelReviewComponent extends Component {
   }
 
   render () {
-    const { classes, transfer, escrowWallet, actionsPending, gasCost } = this.props
+    const { classes, transfer, escrowWallet, actionsPending, txCost } = this.props
     if (transfer) {
       var { sendingId, receiveTxHash, receiveTimestamp, cancelTxHash, cancelTimestamp, transferAmount, sender, destination, cryptoType, sendTimestamp } = transfer
       var hasReceived = !!receiveTxHash
@@ -153,7 +153,7 @@ class CancelReviewComponent extends Component {
                   </Grid>
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                     From
+                      From
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {sender}
@@ -161,7 +161,7 @@ class CancelReviewComponent extends Component {
                   </Grid>
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                     To
+                      To
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {destination}
@@ -169,71 +169,71 @@ class CancelReviewComponent extends Component {
                   </Grid>
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                     Amount
+                      Amount
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {transferAmount} {getCryptoSymbol(cryptoType)}
                     </Typography>
                   </Grid>
                   {!hasReceived && !hasCancelled && // do not show gas in this case
-                  <Grid item className={classes.reviewItem}>
-                    <Typography className={classes.reviewSubtitle} align='left'>
-                      Gas Fee
-                    </Typography>
-                    <Typography className={classes.reviewContent} align='left'>
-                      {!actionsPending.getGasCost && gasCost
-                        ? <Typography className={classes.reviewContent} align='left'>
-                          {gasCost.costInEther} ETH
-                        </Typography>
-                        : <CircularProgress size={18} color='primary' />}
-                    </Typography>
-                  </Grid>
+                    <Grid item className={classes.reviewItem}>
+                      <Typography className={classes.reviewSubtitle} align='left'>
+                        Transaction Fee
+                      </Typography>
+                      <Typography className={classes.reviewContent} align='left'>
+                        {!actionsPending.getTxCost && txCost
+                          ? <Typography className={classes.reviewContent} align='left'>
+                            {txCost.costInStandardUnit} {getCryptoSymbol(cryptoType)}
+                          </Typography>
+                          : <CircularProgress size={18} color='primary' />}
+                      </Typography>
+                    </Grid>
                   }
                   {!hasReceived && !hasCancelled && // do not show gas in this case
-                  <Grid item className={classes.reviewItem}>
-                    <Typography className={classes.reviewSubtitle} align='left'>
-                      Total Cost
-                    </Typography>
-                    <Typography className={classes.reviewContent} align='left'>
-                      {!actionsPending.getGasCost && gasCost
-                        ? <Typography className={classes.reviewContent} align='left'>
-                          {parseFloat(gasCost.costInEther) + parseFloat(transferAmount)} ETH
-                        </Typography>
-                        : <CircularProgress size={18} color='primary' />}
-                    </Typography>
-                  </Grid>
+                    <Grid item className={classes.reviewItem}>
+                      <Typography className={classes.reviewSubtitle} align='left'>
+                        Total Cost
+                      </Typography>
+                      <Typography className={classes.reviewContent} align='left'>
+                        {!actionsPending.getTxCost && txCost
+                          ? <Typography className={classes.reviewContent} align='left'>
+                            {parseFloat(txCost.costInStandardUnit) + parseFloat(transferAmount)} {getCryptoSymbol(cryptoType)}
+                          </Typography>
+                          : <CircularProgress size={18} color='primary' />}
+                      </Typography>
+                    </Grid>
                   }
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                     Sent on
+                      Sent on
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {moment.unix(sendTimestamp).format('MMM Do YYYY, HH:mm:ss')}
                     </Typography>
                   </Grid>
                   {(hasReceived || hasCancelled) &&
-                  <Grid item className={classes.reviewItem}>
-                    <Typography className={classes.reviewSubtitle} align='left'>
-                      {hasReceived && 'Received on'}
-                      {hasCancelled && 'Cancelled on'}
-                    </Typography>
-                    <Typography className={classes.reviewContent} align='left'>
-                      {hasReceived && moment.unix(receiveTimestamp).format('MMM Do YYYY, HH:mm:ss')}
-                      {hasCancelled && moment.unix(cancelTimestamp).format('MMM Do YYYY, HH:mm:ss')}
-                    </Typography>
-                  </Grid>
+                    <Grid item className={classes.reviewItem}>
+                      <Typography className={classes.reviewSubtitle} align='left'>
+                        {hasReceived && 'Received on'}
+                        {hasCancelled && 'Cancelled on'}
+                      </Typography>
+                      <Typography className={classes.reviewContent} align='left'>
+                        {hasReceived && moment.unix(receiveTimestamp).format('MMM Do YYYY, HH:mm:ss')}
+                        {hasCancelled && moment.unix(cancelTimestamp).format('MMM Do YYYY, HH:mm:ss')}
+                      </Typography>
+                    </Grid>
                   }
                   {(hasReceived || hasCancelled) &&
-                  <Grid item>
-                    <Typography color='primary' className={classes.etherscanLink} align='left'>
-                      <MuiLink
-                        target='_blank'
-                        rel='noopener'
-                        href={`https://rinkeby.etherscan.io/tx/${(hasReceived && receiveTxHash) || (hasCancelled && cancelTxHash)}`}>
-                        Check status on Etherscan
-                      </MuiLink>
-                    </Typography>
-                  </Grid>
+                    <Grid item>
+                      <Typography color='primary' className={classes.etherscanLink} align='left'>
+                        <MuiLink
+                          target='_blank'
+                          rel='noopener'
+                          href={`https://rinkeby.etherscan.io/tx/${(hasReceived && receiveTxHash) || (hasCancelled && cancelTxHash)}`}>
+                          Check status on Etherscan
+                        </MuiLink>
+                      </Typography>
+                    </Grid>
                   }
                 </Grid>
               </Grid>
@@ -241,20 +241,20 @@ class CancelReviewComponent extends Component {
           }
         </Grid>
         {!hasReceived && !hasCancelled &&
-        <Grid item className={classes.btnSection}>
-          <Grid container direction='row' justify='center' spacing={24}>
-            <Grid item>
-              <Button
-                fullWidth
-                color='primary'
-                size='large'
-                onClick={this.handleModalOpen}
-              >
-                 Cancel Transfer
-              </Button>
+          <Grid item className={classes.btnSection}>
+            <Grid container direction='row' justify='center' spacing={24}>
+              <Grid item>
+                <Button
+                  fullWidth
+                  color='primary'
+                  size='large'
+                  onClick={this.handleModalOpen}
+                >
+                  Cancel Transfer
+                </Button>
+              </Grid>
             </Grid>
           </Grid>
-        </Grid>
         }
         {this.state.open && this.renderModal()}
       </Grid>

--- a/src/components/CancelReviewComponent.jsx
+++ b/src/components/CancelReviewComponent.jsx
@@ -22,7 +22,7 @@ class CancelReviewComponent extends Component {
     if (transfer) {
       const { sendingId, sendTxHash, transferAmount, cryptoType } = transfer
       if (!actionsPending.cancelTransfer && // cancelTransfer is not currently running
-        !receipt && // cancelTransfer has not been called
+      !receipt && // cancelTransfer has not been called
         open && // cancel popup is currently focused
         escrowWallet.decryptedWallet) { // escrowWallet has been decrypted
         // submit cancelTransfer action
@@ -103,11 +103,11 @@ class CancelReviewComponent extends Component {
                     Cancel Transfer
                   </Button>
                   {(actionsPending.verifyPassword || actionsPending.cancelTransfer) &&
-                    <CircularProgress
-                      size={24}
-                      color='primary'
-                      className={classes.buttonProgress}
-                    />}
+                  <CircularProgress
+                    size={24}
+                    color='primary'
+                    className={classes.buttonProgress}
+                  />}
                 </div>
               </Grid>
             </Grid>
@@ -153,7 +153,7 @@ class CancelReviewComponent extends Component {
                   </Grid>
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                      From
+                     From
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {sender}
@@ -161,7 +161,7 @@ class CancelReviewComponent extends Component {
                   </Grid>
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                      To
+                     To
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {destination}
@@ -169,71 +169,71 @@ class CancelReviewComponent extends Component {
                   </Grid>
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                      Amount
+                     Amount
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {transferAmount} {getCryptoSymbol(cryptoType)}
                     </Typography>
                   </Grid>
                   {!hasReceived && !hasCancelled && // do not show gas in this case
-                    <Grid item className={classes.reviewItem}>
-                      <Typography className={classes.reviewSubtitle} align='left'>
-                        Transaction Fee
-                      </Typography>
-                      <Typography className={classes.reviewContent} align='left'>
-                        {!actionsPending.getTxCost && txCost
-                          ? <Typography className={classes.reviewContent} align='left'>
-                            {txCost.costInStandardUnit} {getCryptoSymbol(cryptoType)}
-                          </Typography>
-                          : <CircularProgress size={18} color='primary' />}
-                      </Typography>
-                    </Grid>
+                  <Grid item className={classes.reviewItem}>
+                    <Typography className={classes.reviewSubtitle} align='left'>
+                      Transaction Fee
+                    </Typography>
+                    <Typography className={classes.reviewContent} align='left'>
+                      {!actionsPending.getTxCost && txCost
+                        ? <Typography className={classes.reviewContent} align='left'>
+                          {txCost.costInStandardUnit} {getCryptoSymbol(cryptoType)}
+                        </Typography>
+                        : <CircularProgress size={18} color='primary' />}
+                    </Typography>
+                  </Grid>
                   }
                   {!hasReceived && !hasCancelled && // do not show gas in this case
-                    <Grid item className={classes.reviewItem}>
-                      <Typography className={classes.reviewSubtitle} align='left'>
-                        Total Cost
-                      </Typography>
-                      <Typography className={classes.reviewContent} align='left'>
-                        {!actionsPending.getTxCost && txCost
-                          ? <Typography className={classes.reviewContent} align='left'>
-                            {parseFloat(txCost.costInStandardUnit) + parseFloat(transferAmount)} {getCryptoSymbol(cryptoType)}
-                          </Typography>
-                          : <CircularProgress size={18} color='primary' />}
-                      </Typography>
-                    </Grid>
+                  <Grid item className={classes.reviewItem}>
+                    <Typography className={classes.reviewSubtitle} align='left'>
+                      Total Cost
+                    </Typography>
+                    <Typography className={classes.reviewContent} align='left'>
+                      {!actionsPending.getTxCost && txCost
+                        ? <Typography className={classes.reviewContent} align='left'>
+                          {parseFloat(txCost.costInStandardUnit) + parseFloat(transferAmount)} {getCryptoSymbol(cryptoType)}
+                        </Typography>
+                        : <CircularProgress size={18} color='primary' />}
+                    </Typography>
+                  </Grid>
                   }
                   <Grid item className={classes.reviewItem}>
                     <Typography className={classes.reviewSubtitle} align='left'>
-                      Sent on
+                     Sent on
                     </Typography>
                     <Typography className={classes.reviewContent} align='left'>
                       {moment.unix(sendTimestamp).format('MMM Do YYYY, HH:mm:ss')}
                     </Typography>
                   </Grid>
                   {(hasReceived || hasCancelled) &&
-                    <Grid item className={classes.reviewItem}>
-                      <Typography className={classes.reviewSubtitle} align='left'>
-                        {hasReceived && 'Received on'}
-                        {hasCancelled && 'Cancelled on'}
-                      </Typography>
-                      <Typography className={classes.reviewContent} align='left'>
-                        {hasReceived && moment.unix(receiveTimestamp).format('MMM Do YYYY, HH:mm:ss')}
-                        {hasCancelled && moment.unix(cancelTimestamp).format('MMM Do YYYY, HH:mm:ss')}
-                      </Typography>
-                    </Grid>
+                  <Grid item className={classes.reviewItem}>
+                    <Typography className={classes.reviewSubtitle} align='left'>
+                      {hasReceived && 'Received on'}
+                      {hasCancelled && 'Cancelled on'}
+                    </Typography>
+                    <Typography className={classes.reviewContent} align='left'>
+                      {hasReceived && moment.unix(receiveTimestamp).format('MMM Do YYYY, HH:mm:ss')}
+                      {hasCancelled && moment.unix(cancelTimestamp).format('MMM Do YYYY, HH:mm:ss')}
+                    </Typography>
+                  </Grid>
                   }
                   {(hasReceived || hasCancelled) &&
-                    <Grid item>
-                      <Typography color='primary' className={classes.etherscanLink} align='left'>
-                        <MuiLink
-                          target='_blank'
-                          rel='noopener'
-                          href={`https://rinkeby.etherscan.io/tx/${(hasReceived && receiveTxHash) || (hasCancelled && cancelTxHash)}`}>
-                          Check status on Etherscan
-                        </MuiLink>
-                      </Typography>
-                    </Grid>
+                  <Grid item>
+                    <Typography color='primary' className={classes.etherscanLink} align='left'>
+                      <MuiLink
+                        target='_blank'
+                        rel='noopener'
+                        href={`https://rinkeby.etherscan.io/tx/${(hasReceived && receiveTxHash) || (hasCancelled && cancelTxHash)}`}>
+                        Check status on Etherscan
+                      </MuiLink>
+                    </Typography>
+                  </Grid>
                   }
                 </Grid>
               </Grid>
@@ -241,20 +241,20 @@ class CancelReviewComponent extends Component {
           }
         </Grid>
         {!hasReceived && !hasCancelled &&
-          <Grid item className={classes.btnSection}>
-            <Grid container direction='row' justify='center' spacing={24}>
-              <Grid item>
-                <Button
-                  fullWidth
-                  color='primary'
-                  size='large'
-                  onClick={this.handleModalOpen}
-                >
-                  Cancel Transfer
-                </Button>
-              </Grid>
+        <Grid item className={classes.btnSection}>
+          <Grid container direction='row' justify='center' spacing={24}>
+            <Grid item>
+              <Button
+                fullWidth
+                color='primary'
+                size='large'
+                onClick={this.handleModalOpen}
+              >
+                Cancel Transfer
+              </Button>
             </Grid>
           </Grid>
+        </Grid>
         }
         {this.state.open && this.renderModal()}
       </Grid>

--- a/src/components/ReceiptComponent.jsx
+++ b/src/components/ReceiptComponent.jsx
@@ -20,7 +20,7 @@ class ReceiptComponent extends Component {
 
   render () {
     const { copied } = this.state
-    const { classes, cryptoSelection, password, txCost, receipt, cryptoSelection } = this.props
+    const { classes, cryptoSelection, password, txCost, receipt } = this.props
     const { sendingId, transferAmount, sender, destination, sendTimestamp } = receipt
     return (
       <Grid container direction='column' justify='center' alignItems='center'>

--- a/src/components/ReceiptComponent.jsx
+++ b/src/components/ReceiptComponent.jsx
@@ -20,7 +20,7 @@ class ReceiptComponent extends Component {
 
   render () {
     const { copied } = this.state
-    const { classes, cryptoSelection, password, gasCost, receipt } = this.props
+    const { classes, cryptoSelection, password, txCost, receipt, cryptoSelection } = this.props
     const { sendingId, transferAmount, sender, destination, sendTimestamp } = receipt
     return (
       <Grid container direction='column' justify='center' alignItems='center'>
@@ -65,10 +65,10 @@ class ReceiptComponent extends Component {
                 </Grid>
                 <Grid item className={classes.reviewItem}>
                   <Typography className={classes.reviewSubtitle} align='left'>
-                    Gas Fee
+                    Transaction Fee
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {`${gasCost.costInEther} ETH`}
+                    {`${txCost.costInStandardUnit} ${getCryptoSymbol(cryptoSelection)}`}
                   </Typography>
                 </Grid>
                 <Grid item className={classes.reviewItem}>
@@ -76,7 +76,7 @@ class ReceiptComponent extends Component {
                     Total Cost
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {`${parseFloat(gasCost.costInEther) + parseFloat(transferAmount)} ETH`}
+                    {`${parseFloat(txCost.costInStandardUnit) + parseFloat(transferAmount)} ${getCryptoSymbol(cryptoSelection)}`}
                   </Typography>
                 </Grid>
                 <Grid item className={classes.reviewItem}>

--- a/src/components/ReceiveReceiptComponent.jsx
+++ b/src/components/ReceiveReceiptComponent.jsx
@@ -14,7 +14,7 @@ import { getCryptoSymbol } from '../tokens'
 
 class ReceiveReceiptComponent extends Component {
   render () {
-    const { classes, gasCost, receipt } = this.props
+    const { classes, cryptoSelection, txCost, receipt } = this.props
     const { receivingId, transferAmount, sender, destination, cryptoType, receiveTimestamp, receiveTxHash } = receipt
     return (
       <Grid container direction='column' justify='center' alignItems='center'>
@@ -59,10 +59,10 @@ class ReceiveReceiptComponent extends Component {
                 </Grid>
                 <Grid item className={classes.reviewItem}>
                   <Typography className={classes.reviewSubtitle} align='left'>
-                    Gas Fee
+                    Transaction Fee
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {`${gasCost.costInEther} ETH`}
+                    {`${txCost.costInStandardUnit} ${getCryptoSymbol(cryptoSelection)}`}
                   </Typography>
                 </Grid>
                 <Grid item className={classes.reviewItem}>
@@ -70,7 +70,7 @@ class ReceiveReceiptComponent extends Component {
                     You will receive*
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {`${parseFloat(transferAmount) - parseFloat(gasCost.costInEther)} ETH`}
+                    {`${parseFloat(transferAmount) - parseFloat(txCost.costInStandardUnit)} ${getCryptoSymbol(cryptoSelection)}`}
                   </Typography>
                 </Grid>
                 <Grid item className={classes.reviewItem}>

--- a/src/components/ReceiveReviewComponent.jsx
+++ b/src/components/ReceiveReviewComponent.jsx
@@ -18,7 +18,7 @@ class ReceiveReviewComponent extends Component {
     this.props.acceptTransfer({
       receivingId: receivingId,
       escrowWallet: escrowWallet.decryptedWallet,
-      destinationAddress: wallet.accounts[0].address,
+      destinationAddress: wallet.crypto[transfer.cryptoType][0].address,
       walletType: walletSelection,
       cryptoType: transfer.cryptoType,
       transferAmount: transferAmount,
@@ -29,14 +29,14 @@ class ReceiveReviewComponent extends Component {
   componentDidMount () {
     // refresh gas cost
     const { transfer } = this.props
-    this.props.getTxCost({ cryptoType: transfer.cryptoType })
+    this.props.getTxCost({ cryptoType: transfer.cryptoType, transferAmount: transfer.transferAmount })
   }
 
   render () {
     const { classes, wallet, transfer, cryptoSelection, actionsPending, txCost } = this.props
     const { transferAmount, sender, destination, cryptoType, sendTimestamp } = transfer
 
-    var address = wallet.accounts[0].address
+    var address = wallet.crypto[cryptoType][0].address
 
     return (
       <Grid container direction='column' justify='center' alignItems='stretch'>

--- a/src/components/ReceiveReviewComponent.jsx
+++ b/src/components/ReceiveReviewComponent.jsx
@@ -10,7 +10,7 @@ import { getCryptoSymbol } from '../tokens'
 
 class ReceiveReviewComponent extends Component {
   handleReviewNext = () => {
-    const { transfer, escrowWallet, wallet, walletSelection, gasCost } = this.props
+    const { transfer, escrowWallet, wallet, walletSelection, txCost } = this.props
     const { receivingId, transferAmount } = transfer
 
     // accept transfer
@@ -22,18 +22,18 @@ class ReceiveReviewComponent extends Component {
       walletType: walletSelection,
       cryptoType: transfer.cryptoType,
       transferAmount: transferAmount,
-      gasCost: gasCost
+      txCost: txCost
     })
   }
 
   componentDidMount () {
     // refresh gas cost
     const { transfer } = this.props
-    this.props.getGasCost({ cryptoType: transfer.cryptoType })
+    this.props.getTxCost({ cryptoType: transfer.cryptoType })
   }
 
   render () {
-    const { classes, wallet, transfer, actionsPending, gasCost } = this.props
+    const { classes, wallet, transfer, cryptoSelection, actionsPending, txCost } = this.props
     const { transferAmount, sender, destination, cryptoType, sendTimestamp } = transfer
 
     var address = wallet.accounts[0].address
@@ -91,11 +91,11 @@ class ReceiveReviewComponent extends Component {
                 </Grid>
                 <Grid item className={classes.reviewItem}>
                   <Typography className={classes.reviewSubtitle} align='left'>
-                    Gas Fee
+                    Transaction Fee
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {!actionsPending.getGasCost && gasCost
-                      ? `${gasCost.costInEther} ETH`
+                    {!actionsPending.getTxCost && txCost
+                      ? `${txCost.costInStandardUnit} ${getCryptoSymbol(cryptoSelection)}`
                       : <CircularProgress size={18} color='primary' />}
                   </Typography>
                 </Grid>
@@ -104,8 +104,8 @@ class ReceiveReviewComponent extends Component {
                     You will receive*
                   </Typography>
                   <Typography className={classes.reviewContent} align='left'>
-                    {!actionsPending.getGasCost && gasCost
-                      ? `${parseFloat(transferAmount) - parseFloat(gasCost.costInEther)} ETH`
+                    {!actionsPending.getTxCost && txCost
+                      ? `${parseFloat(transferAmount) - parseFloat(txCost.costInStandardUnit)} ${getCryptoSymbol(cryptoSelection)}`
                       : <CircularProgress size={18} color='primary' />}
                   </Typography>
                 </Grid>

--- a/src/components/ReceiveWalletSelectionComponent.jsx
+++ b/src/components/ReceiveWalletSelectionComponent.jsx
@@ -87,7 +87,7 @@ class ReceiveWalletSelectionComponent extends Component {
   }
 
   renderWalletConnectionNotification = () => {
-    let { classes, actionsPending, walletType, wallet } = this.props
+    let { classes, actionsPending, walletType, wallet, transfer } = this.props
 
     if ((walletType === 'metamask' && actionsPending.checkMetamaskConnection) ||
         (walletType === 'ledger' && actionsPending.checkLedgerNanoSConnection)) {
@@ -140,7 +140,7 @@ class ReceiveWalletSelectionComponent extends Component {
               <Grid item>
                 <Typography className={classes.notificationAddress}>
                   Wallet address:
-                  { wallet.accounts[0].address }
+                  { wallet.crypto[transfer.cryptoType][0].address }
                 </Typography>
               </Grid>
             </Grid>

--- a/src/components/RecipientComponent.jsx
+++ b/src/components/RecipientComponent.jsx
@@ -58,7 +58,7 @@ class RecipientComponent extends Component {
       [name]: { $set: event.target.value }
     }))
 
-    let balance = wallet ? wallet.accounts[0].balance[cryptoSelection] : null
+    let balance = wallet ? wallet.crypto[cryptoSelection][0].balance : null
     const decimals = getCryptoDecimals(cryptoSelection)
     // validation
     if (name === 'transferAmount') {
@@ -120,7 +120,7 @@ class RecipientComponent extends Component {
     const { classes, transferForm, wallet, cryptoSelection } = this.props
     const { transferAmount, destination, password, sender } = transferForm
 
-    let balance = wallet.accounts[0].balance[cryptoSelection] ? numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoSelection], getCryptoDecimals(cryptoSelection))).format('0.000a') : '0'
+    let balance = wallet.crypto[cryptoSelection][0].balance ? numeral(utils.toHumanReadableUnit(wallet.crypto[cryptoSelection][0].balance, getCryptoDecimals(cryptoSelection))).format('0.000a') : '0'
 
     return (
       <Grid container direction='column' justify='center' alignItems='stretch' spacing={24}>

--- a/src/components/RecipientComponent.jsx
+++ b/src/components/RecipientComponent.jsx
@@ -8,6 +8,7 @@ import update from 'immutability-helper'
 import utils from '../utils'
 import numeral from 'numeral'
 import validator from 'validator'
+import { getCryptoDecimals } from '../tokens'
 
 class RecipientComponent extends Component {
   state = {
@@ -51,22 +52,22 @@ class RecipientComponent extends Component {
   }
 
   handleTransferFormChange = name => event => {
-    const { transferForm, wallet } = this.props
+    const { transferForm, wallet, cryptoSelection } = this.props
 
     this.props.updateTransferForm(update(transferForm, {
       [name]: { $set: event.target.value }
     }))
 
-    let balance = wallet ? wallet.accounts[0].balance['ethereum'] : null
-
+    let balance = wallet ? wallet.accounts[0].balance[cryptoSelection] : null
+    const decimals = getCryptoDecimals(cryptoSelection)
     // validation
     if (name === 'transferAmount') {
       if (wallet && balance &&
-          !validator.isFloat(event.target.value, { min: 0.0001, max: utils.toHumanReadableUnit(balance) })) {
+          !validator.isFloat(event.target.value, { min: 0.0001, max: utils.toHumanReadableUnit(balance, decimals) })) {
         if (event.target.value === '-' || parseFloat(event.target.value) < 0.0001) {
           this.setState(update(this.state, { formError: { [name]: { $set: 'The amount must be greater than 0.0001' } } }))
         } else {
-          this.setState(update(this.state, { formError: { [name]: { $set: `The amount cannot exceed your current balance ${utils.toHumanReadableUnit(balance)}` } } }))
+          this.setState(update(this.state, { formError: { [name]: { $set: `The amount cannot exceed your current balance ${utils.toHumanReadableUnit(balance, decimals)}` } } }))
         }
       } else {
         this.setState(update(this.state, { formError: { [name]: { $set: null } } }))
@@ -119,7 +120,7 @@ class RecipientComponent extends Component {
     const { classes, transferForm, wallet, cryptoSelection } = this.props
     const { transferAmount, destination, password, sender } = transferForm
 
-    let balance = wallet.accounts[0].balance[cryptoSelection] ? numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoSelection])).format('0.000a') : '0'
+    let balance = wallet.accounts[0].balance[cryptoSelection] ? numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoSelection], getCryptoDecimals(cryptoSelection))).format('0.000a') : '0'
 
     return (
       <Grid container direction='column' justify='center' alignItems='stretch' spacing={24}>

--- a/src/components/ReviewComponent.jsx
+++ b/src/components/ReviewComponent.jsx
@@ -27,8 +27,8 @@ class ReviewComponent extends Component {
 
   componentDidMount () {
     // refresh gas cost
-    const { cryptoSelection, getTxCost } = this.props
-    getTxCost({ cryptoType: cryptoSelection })
+    const { cryptoSelection, getTxCost, transferForm } = this.props
+    getTxCost({ cryptoType: cryptoSelection, transferAmount: transferForm.transferAmount })
   }
 
   render () {

--- a/src/components/ReviewComponent.jsx
+++ b/src/components/ReviewComponent.jsx
@@ -9,7 +9,7 @@ import { getCryptoSymbol } from '../tokens'
 
 class ReviewComponent extends Component {
   handleReviewNext = () => {
-    const { wallet, transferForm, cryptoSelection, walletSelection, gasCost } = this.props
+    const { wallet, transferForm, cryptoSelection, walletSelection, txCost } = this.props
     const { transferAmount, sender, destination, password } = transferForm
 
     // submit tx
@@ -21,18 +21,18 @@ class ReviewComponent extends Component {
       destination: destination,
       sender: sender,
       password: password,
-      gasCost: gasCost
+      txCost: txCost
     })
   }
 
   componentDidMount () {
     // refresh gas cost
-    const { cryptoSelection } = this.props
-    this.props.getGasCost({ cryptoType: cryptoSelection })
+    const { cryptoSelection, getTxCost } = this.props
+    getTxCost({ cryptoType: cryptoSelection })
   }
 
   render () {
-    const { classes, transferForm, cryptoSelection, actionsPending, gasCost } = this.props
+    const { classes, transferForm, cryptoSelection, actionsPending, txCost } = this.props
     const { transferAmount, sender, destination, password } = transferForm
 
     return (
@@ -78,30 +78,26 @@ class ReviewComponent extends Component {
                     {transferAmount} {getCryptoSymbol(cryptoSelection)}
                   </Typography>
                 </Grid>
-                {cryptoSelection !== 'bitcoin' ? <div>
-                  <Grid item className={classes.reviewItem}>
-                    <Typography className={classes.reviewSubtitle} align='left'>
-                      Gas Fee
+                <Grid item className={classes.reviewItem}>
+                  <Typography className={classes.reviewSubtitle} align='left'>
+                    Transaction Fee
+                  </Typography>
+                  {!actionsPending.getTxCost && txCost
+                    ? <Typography className={classes.reviewContent} align='left'>
+                      {txCost.costInStandardUnit} {getCryptoSymbol(cryptoSelection)}
                     </Typography>
-                    {!actionsPending.getGasCost && gasCost
-                      ? <Typography className={classes.reviewContent} align='left'>
-                        {gasCost.costInEther} ETH
-                      </Typography>
-                      : <CircularProgress size={18} color='primary' />}
-                  </Grid>
-                  <Grid item>
-                    <Typography className={classes.reviewSubtitle} align='left'>
-                      Total Cost
+                    : <CircularProgress size={18} color='primary' />}
+                </Grid>
+                <Grid item>
+                  <Typography className={classes.reviewSubtitle} align='left'>
+                    Total Cost
+                  </Typography>
+                  {!actionsPending.getTxCost && txCost
+                    ? <Typography className={classes.reviewContent} align='left'>
+                      {parseFloat(txCost.costInStandardUnit) + parseFloat(transferAmount)} {getCryptoSymbol(cryptoSelection)}
                     </Typography>
-                    {!actionsPending.getGasCost && gasCost
-                      ? <Typography className={classes.reviewContent} align='left'>
-                        {parseFloat(gasCost.costInEther) + parseFloat(transferAmount)} ETH
-                      </Typography>
-                      : <CircularProgress size={18} color='primary' />}
-                  </Grid>
-                </div>
-                  : null
-                }
+                    : <CircularProgress size={18} color='primary' />}
+                </Grid>
               </Paper>
             </Grid>
           </Grid>

--- a/src/components/ReviewComponent.jsx
+++ b/src/components/ReviewComponent.jsx
@@ -78,26 +78,30 @@ class ReviewComponent extends Component {
                     {transferAmount} {getCryptoSymbol(cryptoSelection)}
                   </Typography>
                 </Grid>
-                <Grid item className={classes.reviewItem}>
-                  <Typography className={classes.reviewSubtitle} align='left'>
-                    Gas Fee
-                  </Typography>
-                  {!actionsPending.getGasCost && gasCost
-                    ? <Typography className={classes.reviewContent} align='left'>
-                      {gasCost.costInEther} ETH
+                {cryptoSelection !== 'bitcoin' ? <div>
+                  <Grid item className={classes.reviewItem}>
+                    <Typography className={classes.reviewSubtitle} align='left'>
+                      Gas Fee
                     </Typography>
-                    : <CircularProgress size={18} color='primary' />}
-                </Grid>
-                <Grid item>
-                  <Typography className={classes.reviewSubtitle} align='left'>
-                    Total Cost
-                  </Typography>
-                  {!actionsPending.getGasCost && gasCost
-                    ? <Typography className={classes.reviewContent} align='left'>
-                      {parseFloat(gasCost.costInEther) + parseFloat(transferAmount)} ETH
+                    {!actionsPending.getGasCost && gasCost
+                      ? <Typography className={classes.reviewContent} align='left'>
+                        {gasCost.costInEther} ETH
+                      </Typography>
+                      : <CircularProgress size={18} color='primary' />}
+                  </Grid>
+                  <Grid item>
+                    <Typography className={classes.reviewSubtitle} align='left'>
+                      Total Cost
                     </Typography>
-                    : <CircularProgress size={18} color='primary' />}
-                </Grid>
+                    {!actionsPending.getGasCost && gasCost
+                      ? <Typography className={classes.reviewContent} align='left'>
+                        {parseFloat(gasCost.costInEther) + parseFloat(transferAmount)} ETH
+                      </Typography>
+                      : <CircularProgress size={18} color='primary' />}
+                  </Grid>
+                </div>
+                  : null
+                }
               </Paper>
             </Grid>
           </Grid>

--- a/src/components/WalletSelectionComponent.jsx
+++ b/src/components/WalletSelectionComponent.jsx
@@ -87,7 +87,7 @@ class WalletSelectionComponent extends Component {
           </Grid>
         </Grid>
       )
-    } else if (actionsPending.loadAccountInfo) {
+    } else if (actionsPending.syncAccountInfo) {
       return (
         <Grid container direction='column' justify='center' alignItems='center'>
           <Grid item>
@@ -98,7 +98,7 @@ class WalletSelectionComponent extends Component {
           </Grid>
         </Grid>
       )
-    } else if (wallet && wallet.accounts && wallet.accounts[0].balance[cryptoType] && !actionsPending.loadAccountInfo) {
+    } else if (wallet && wallet.crypto[cryptoType] && wallet.crypto[cryptoType][0] && !actionsPending.syncAccountInfo) {
       return (
         <Grid container direction='row' alignItems='center'>
           <Grid item>
@@ -106,7 +106,7 @@ class WalletSelectionComponent extends Component {
           </Grid>
           <Grid item>
             <Typography className={classes.connectedtext}>Account retrieved, your balance: {
-              numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoType], getCryptoDecimals(cryptoType))).format('0.000a')} {getCryptoSymbol(cryptoType)}
+              numeral(utils.toHumanReadableUnit(wallet.crypto[cryptoType][0].balance, getCryptoDecimals(cryptoType))).format('0.000a')} {getCryptoSymbol(cryptoType)}
             </Typography>
           </Grid>
         </Grid>
@@ -125,7 +125,7 @@ class WalletSelectionComponent extends Component {
             <ListItem
               button
               onClick={() => onCryptoSelected(c.cryptoType)}
-              disabled={this.cryptoDisabled(c, walletType) || actionsPending.loadAccountInfo}
+              disabled={this.cryptoDisabled(c, walletType) || actionsPending.syncAccountInfo || actionsPending.checkWalletConnection}
               className={classes.cryptoListItem}
             >
               <Radio
@@ -196,7 +196,7 @@ class WalletSelectionComponent extends Component {
                 color='primary'
                 size='large'
                 onClick={() => this.props.goToStep(1)}
-                disabled={!walletType || !cryptoType || !wallet.connected || actionsPending.checkWalletConnection || wallet.accounts === null || actionsPending.loadAccountInfo}
+                disabled={!walletType || !cryptoType || !wallet.connected || actionsPending.checkWalletConnection || !wallet.crypto[cryptoType] || actionsPending.syncAccountInfo}
               >
               Continue
               </Button>

--- a/src/components/WalletSelectionComponent.jsx
+++ b/src/components/WalletSelectionComponent.jsx
@@ -17,7 +17,7 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import utils from '../utils'
 import numeral from 'numeral'
 import { walletCryptoSupports, walletSelections } from '../wallet'
-import { cryptoSelections, getCryptoSymbol } from '../tokens'
+import { cryptoSelections, getCryptoSymbol, getCryptoDecimals } from '../tokens'
 
 const WalletConnectionErrorMessage = {
   'metamask': 'Please make sure MetaMask is installed and authorization is accepted',
@@ -98,7 +98,7 @@ class WalletSelectionComponent extends Component {
         </Grid>
         <Grid item>
           <Typography className={classes.connectedtext}>Account retrieved, your balance: {
-            numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoType])).format('0.000a')} {getCryptoSymbol(cryptoType)}
+            numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoType], getCryptoDecimals(cryptoType))).format('0.000a')} {getCryptoSymbol(cryptoType)}
           </Typography>
         </Grid>
       </Grid>

--- a/src/components/WalletSelectionComponent.jsx
+++ b/src/components/WalletSelectionComponent.jsx
@@ -76,9 +76,7 @@ class WalletSelectionComponent extends Component {
           </Grid>
         </Grid>
       )
-    }
-
-    if (!wallet.connected) {
+    } else if (!wallet.connected) {
       return (
         <Grid container direction='row' alignItems='center'>
           <Grid item>
@@ -89,24 +87,35 @@ class WalletSelectionComponent extends Component {
           </Grid>
         </Grid>
       )
+    } else if (actionsPending.loadAccountInfo) {
+      return (
+        <Grid container direction='column' justify='center' alignItems='center'>
+          <Grid item>
+            <CircularProgress className={classes.circularProgress} />
+          </Grid>
+          <Grid item>
+            <Typography className={classes.connectedtext}>Synchronizing Acoount Info</Typography>
+          </Grid>
+        </Grid>
+      )
+    } else if (wallet && wallet.accounts && wallet.accounts[0].balance[cryptoType] && !actionsPending.loadAccountInfo) {
+      return (
+        <Grid container direction='row' alignItems='center'>
+          <Grid item>
+            <CheckIcon className={classes.connectedIcon} />
+          </Grid>
+          <Grid item>
+            <Typography className={classes.connectedtext}>Account retrieved, your balance: {
+              numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoType], getCryptoDecimals(cryptoType))).format('0.000a')} {getCryptoSymbol(cryptoType)}
+            </Typography>
+          </Grid>
+        </Grid>
+      )
     }
-
-    return (
-      <Grid container direction='row' alignItems='center'>
-        <Grid item>
-          <CheckIcon className={classes.connectedIcon} />
-        </Grid>
-        <Grid item>
-          <Typography className={classes.connectedtext}>Account retrieved, your balance: {
-            numeral(utils.toHumanReadableUnit(wallet.accounts[0].balance[cryptoType], getCryptoDecimals(cryptoType))).format('0.000a')} {getCryptoSymbol(cryptoType)}
-          </Typography>
-        </Grid>
-      </Grid>
-    )
   }
 
   renderCryptoSelection = () => {
-    const { classes, walletType, cryptoType, onCryptoSelected } = this.props
+    const { classes, walletType, cryptoType, onCryptoSelected, actionsPending } = this.props
 
     return (
       <List className={classes.cryptoList}>
@@ -116,7 +125,7 @@ class WalletSelectionComponent extends Component {
             <ListItem
               button
               onClick={() => onCryptoSelected(c.cryptoType)}
-              disabled={this.cryptoDisabled(c, walletType)}
+              disabled={this.cryptoDisabled(c, walletType) || actionsPending.loadAccountInfo}
               className={classes.cryptoListItem}
             >
               <Radio
@@ -187,7 +196,7 @@ class WalletSelectionComponent extends Component {
                 color='primary'
                 size='large'
                 onClick={() => this.props.goToStep(1)}
-                disabled={!walletType || !cryptoType || !wallet.connected || actionsPending.checkWalletConnection}
+                disabled={!walletType || !cryptoType || !wallet.connected || actionsPending.checkWalletConnection || wallet.accounts === null || actionsPending.loadAccountInfo}
               >
               Continue
               </Button>

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -3,7 +3,7 @@ import thunk from 'redux-thunk'
 import promiseMiddleware from 'redux-promise-middleware'
 import errorMiddleware from './errorMiddleware'
 import logger from 'redux-logger'
-import { persistStore, persistReducer } from 'redux-persist'
+import { persistStore, persistReducer, createTransform } from 'redux-persist'
 import storage from 'redux-persist/lib/storage'
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2'
 import reducers from './reducers'
@@ -20,11 +20,34 @@ function configureStore (reducers) {
   return createStore(reducers, enhancer)
 }
 
+const serializeTransform = createTransform(
+  // transform state on its way to being serialized and persisted.
+  (inboundState, key) => {
+    let serializeState = {
+      wallet: {
+        ledger: {
+          crypto: JSON.parse(JSON.stringify(inboundState.wallet.ledger.crypto))
+        }
+      }
+    }
+    return serializeState
+  },
+  // transform state being rehydrated
+  (outboundState, key) => {
+    return outboundState
+  },
+  // define which reducers this transform gets called for.
+  { whitelist: ['walletReducer'] }
+)
+
 const persistConfig = {
   key: 'root',
   storage,
   stateReconciler: autoMergeLevel2,
-  whitelist: ['userReducer']
+  transforms: [
+    serializeTransform
+  ],
+  whitelist: ['userReducer', 'walletReducer']
 }
 
 const persistedReducer = persistReducer(persistConfig, reducers(history))

--- a/src/containers/CancelReceiptContainer.jsx
+++ b/src/containers/CancelReceiptContainer.jsx
@@ -22,7 +22,7 @@ const mapDispatchToProps = dispatch => {
 const mapStateToProps = state => {
   return {
     receipt: state.transferReducer.receipt,
-    gasCost: state.transferReducer.gasCost
+    txCost: state.transferReducer.txCost
   }
 }
 

--- a/src/containers/CancelReviewContainer.jsx
+++ b/src/containers/CancelReviewContainer.jsx
@@ -21,7 +21,7 @@ class CancelReviewContainer extends Component {
     if (!error && transfer) {
       if (!txCost && !actionsPending.getTxCost) {
         // get gas cost
-        this.props.getTxCost({ cryptoType: transfer.cryptoType })
+        this.props.getTxCost({ cryptoType: transfer.cryptoType, transferAmount: transfer.transferAmount })
       }
     }
   }

--- a/src/containers/CancelReviewContainer.jsx
+++ b/src/containers/CancelReviewContainer.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
 import CancelReviewComponent from '../components/CancelReviewComponent'
-import { getTransfer, cancelTransfer, getGasCost } from '../actions/transferActions'
+import { getTransfer, cancelTransfer, getTxCost } from '../actions/transferActions'
 import { createLoadingSelector, createErrorSelector } from '../selectors'
 import { goToStep } from '../actions/navigationActions'
 import { verifyPassword } from '../actions/walletActions'
@@ -17,11 +17,11 @@ class CancelReviewContainer extends Component {
   }
 
   componentDidUpdate () {
-    let { transfer, gasCost, actionsPending, error } = this.props
+    let { transfer, txCost, actionsPending, error } = this.props
     if (!error && transfer) {
-      if (!gasCost && !actionsPending.getGasCost) {
+      if (!txCost && !actionsPending.getTxCost) {
         // get gas cost
-        this.props.getGasCost({ cryptoType: transfer.cryptoType })
+        this.props.getTxCost({ cryptoType: transfer.cryptoType })
       }
     }
   }
@@ -37,7 +37,7 @@ class CancelReviewContainer extends Component {
 
 const getTransferSelector = createLoadingSelector(['GET_TRANSFER'])
 const verifyPasswordSelector = createLoadingSelector(['VERIFY_PASSWORD'])
-const getGasCostSelector = createLoadingSelector(['GET_GAS_COST'])
+const getTxCostSelector = createLoadingSelector(['GET_TX_COST'])
 const cancelTransferSelector = createLoadingSelector(['CANCEL_TRANSFER', 'CANCEL_TRANSFER_TRANSACTION_HASH_RETRIEVED'])
 const errorSelector = createErrorSelector(['GET_TRANSFER', 'VERIFY_PASSWORD', 'CANCEL_TRANSFER', 'GET_PASSWORD'])
 
@@ -45,7 +45,7 @@ const mapDispatchToProps = dispatch => {
   return {
     getTransfer: (id) => dispatch(getTransfer(id)), // here we use sendingId
     verifyPassword: (encriptedWallet, password) => dispatch(verifyPassword(encriptedWallet, password)),
-    getGasCost: (txRequest) => dispatch(getGasCost(txRequest)),
+    getTxCost: (txRequest) => dispatch(getTxCost(txRequest)),
     cancelTransfer: (txRequest) => dispatch(cancelTransfer(txRequest)),
     goToStep: (n) => dispatch(goToStep('receive', n))
   }
@@ -55,12 +55,12 @@ const mapStateToProps = state => {
   return {
     transfer: state.transferReducer.transfer,
     escrowWallet: state.walletReducer.escrowWallet,
-    gasCost: state.transferReducer.gasCost,
+    txCost: state.transferReducer.txCost,
     receipt: state.transferReducer.receipt,
     actionsPending: {
       getTransfer: getTransferSelector(state),
       verifyPassword: verifyPasswordSelector(state),
-      getGasCost: getGasCostSelector(state),
+      getTxCost: getTxCostSelector(state),
       cancelTransfer: cancelTransferSelector(state)
     },
     error: errorSelector(state)

--- a/src/containers/ReceiptContainer.jsx
+++ b/src/containers/ReceiptContainer.jsx
@@ -17,7 +17,7 @@ const mapStateToProps = state => {
   return {
     cryptoSelection: state.formReducer.cryptoSelection,
     wallet: state.walletReducer.wallet[state.formReducer.walletSelection],
-    gasCost: state.transferReducer.gasCost,
+    txCost: state.transferReducer.txCost,
     receipt: state.transferReducer.receipt,
     password: state.formReducer.transferForm.password
   }

--- a/src/containers/ReceiveReceiptContainer.jsx
+++ b/src/containers/ReceiveReceiptContainer.jsx
@@ -23,7 +23,7 @@ const mapStateToProps = state => {
   return {
     cryptoSelection: state.formReducer.cryptoSelection,
     wallet: state.walletReducer.wallet[state.formReducer.walletSelection],
-    gasCost: state.transferReducer.gasCost,
+    txCost: state.transferReducer.txCost,
     receipt: state.transferReducer.receipt
   }
 }

--- a/src/containers/ReceiveReviewContainer.jsx
+++ b/src/containers/ReceiveReviewContainer.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import ReceiveReview from '../components/ReceiveReviewComponent'
-import { acceptTransfer, getGasCost } from '../actions/transferActions'
+import { acceptTransfer, getTxCost } from '../actions/transferActions'
 import { createLoadingSelector, createErrorSelector } from '../selectors'
 import { goToStep } from '../actions/navigationActions'
 
@@ -16,14 +16,14 @@ class ReceiveReviewContainer extends Component {
 }
 
 const acceptTransferSelector = createLoadingSelector(['ACCEPT_TRANSFER', 'ACCEPT_TRANSFER_TRANSACTION_HASH_RETRIEVED'])
-const getGasCostSelector = createLoadingSelector(['GET_GAS_COST'])
+const getTxCostSelector = createLoadingSelector(['GET_TX_COST'])
 
 const errorSelector = createErrorSelector(['ACCEPT_TRANSFER', 'ACCEPT_TRANSFER_TRANSACTION_HASH_RETRIEVED'])
 
 const mapDispatchToProps = dispatch => {
   return {
     acceptTransfer: (txRequest) => dispatch(acceptTransfer(txRequest)),
-    getGasCost: (txRequest) => dispatch(getGasCost(txRequest)),
+    getTxCost: (txRequest) => dispatch(getTxCost(txRequest)),
     goToStep: (n) => dispatch(goToStep('receive', n))
   }
 }
@@ -34,10 +34,10 @@ const mapStateToProps = state => {
     escrowWallet: state.walletReducer.escrowWallet,
     walletSelection: state.formReducer.walletSelection,
     wallet: state.walletReducer.wallet[state.formReducer.walletSelection],
-    gasCost: state.transferReducer.gasCost,
+    txCost: state.transferReducer.txCost,
     actionsPending: {
       acceptTransfer: acceptTransferSelector(state),
-      getGasCost: getGasCostSelector(state)
+      getTxCost: getTxCostSelector(state)
     },
     error: errorSelector(state)
   }

--- a/src/containers/ReviewContainer.jsx
+++ b/src/containers/ReviewContainer.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import Review from '../components/ReviewComponent'
-import { submitTx, getGasCost } from '../actions/transferActions'
+import { submitTx, getTxCost } from '../actions/transferActions'
 import { createLoadingSelector, createErrorSelector } from '../selectors'
 import { goToStep } from '../actions/navigationActions'
 
@@ -16,14 +16,14 @@ class ReviewContainer extends Component {
 }
 
 const submitTxSelector = createLoadingSelector(['SUBMIT_TX', 'TRANSACTION_HASH_RETRIEVED'])
-const getGasCostSelector = createLoadingSelector(['GET_GAS_COST'])
+const getTxCostSelector = createLoadingSelector(['GET_TX_COST'])
 
 const errorSelector = createErrorSelector(['SUBMIT_TX', 'TRANSACTION_HASH_RETRIEVED'])
 
 const mapDispatchToProps = dispatch => {
   return {
     submitTx: (txRequest) => dispatch(submitTx(txRequest)),
-    getGasCost: (txRequest) => dispatch(getGasCost(txRequest)),
+    getTxCost: (txRequest) => dispatch(getTxCost(txRequest)),
     goToStep: (n) => dispatch(goToStep('send', n))
   }
 }
@@ -34,10 +34,10 @@ const mapStateToProps = state => {
     cryptoSelection: state.formReducer.cryptoSelection,
     walletSelection: state.formReducer.walletSelection,
     wallet: state.walletReducer.wallet[state.formReducer.walletSelection],
-    gasCost: state.transferReducer.gasCost,
+    txCost: state.transferReducer.txCost,
     actionsPending: {
       submitTx: submitTxSelector(state),
-      getGasCost: getGasCostSelector(state)
+      getTxCost: getTxCostSelector(state)
     },
     error: errorSelector(state)
   }

--- a/src/containers/WalletSelectionContainer.jsx
+++ b/src/containers/WalletSelectionContainer.jsx
@@ -50,7 +50,7 @@ const errorSelector = createErrorSelector(['CHECK_METAMASK_CONNECTION'])
 const mapDispatchToProps = dispatch => {
   return {
     checkMetamaskConnection: (cryptoType) => dispatch(checkMetamaskConnection(cryptoType)),
-    checkLedgerNanoSConnection: () => dispatch(checkLedgerNanoSConnection()),
+    checkLedgerNanoSConnection: (cryptoType) => dispatch(checkLedgerNanoSConnection(cryptoType)),
     selectCrypto: (c) => dispatch(selectCrypto(c)),
     selectWallet: (w) => dispatch(selectWallet(w)),
     goToStep: (n) => dispatch(goToStep('send', n))

--- a/src/containers/WalletSelectionContainer.jsx
+++ b/src/containers/WalletSelectionContainer.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import WalletSelection from '../components/WalletSelectionComponent'
-import { checkMetamaskConnection, checkLedgerNanoSConnection } from '../actions/walletActions'
+import { checkMetamaskConnection, checkLedgerNanoSConnection, loadLedgerAccountInfo } from '../actions/walletActions'
 import { selectCrypto, selectWallet } from '../actions/formActions'
 import { createLoadingSelector, createErrorSelector } from '../selectors'
 import { goToStep } from '../actions/navigationActions'
@@ -46,6 +46,7 @@ class WalletSelectionContainer extends Component {
 
 const checkWalletConnectionSelector = createLoadingSelector(['CHECK_METAMASK_CONNECTION', 'CHECK_LEDGER_NANOS_CONNECTION'])
 const errorSelector = createErrorSelector(['CHECK_METAMASK_CONNECTION'])
+const loadAccountInfoSelector = createLoadingSelector(['SYNC_LEDGER_ACCOUNT_INFO', 'LOAD_LEDGER_ACCOUNT_INFO'])
 
 const mapDispatchToProps = dispatch => {
   return {
@@ -53,7 +54,8 @@ const mapDispatchToProps = dispatch => {
     checkLedgerNanoSConnection: (cryptoType) => dispatch(checkLedgerNanoSConnection(cryptoType)),
     selectCrypto: (c) => dispatch(selectCrypto(c)),
     selectWallet: (w) => dispatch(selectWallet(w)),
-    goToStep: (n) => dispatch(goToStep('send', n))
+    goToStep: (n) => dispatch(goToStep('send', n)),
+    loadLedgerAccountInfo: (cryptoType, accountIndex) => dispatch(loadLedgerAccountInfo(cryptoType, accountIndex))
   }
 }
 
@@ -63,7 +65,8 @@ const mapStateToProps = state => {
     cryptoSelection: state.formReducer.cryptoSelection,
     wallet: state.walletReducer.wallet[state.formReducer.walletSelection],
     actionsPending: {
-      checkWalletConnection: checkWalletConnectionSelector(state)
+      checkWalletConnection: checkWalletConnectionSelector(state),
+      loadAccountInfo: loadAccountInfoSelector(state)
     },
     error: errorSelector(state)
   }

--- a/src/containers/WalletSelectionContainer.jsx
+++ b/src/containers/WalletSelectionContainer.jsx
@@ -17,16 +17,16 @@ class WalletSelectionContainer extends Component {
     } = this.props
     if (walletSelection === 'ledger' && cryptoType !== cryptoSelection) {
       checkLedgerNanoSConnection(cryptoType)
+      selectCrypto(cryptoType)
     } else if (walletSelection === 'metamask' && cryptoType !== cryptoSelection) {
       checkMetamaskConnection(cryptoType)
+      selectCrypto(cryptoType)
     }
-
-    selectCrypto(cryptoType)
   }
 
   componentDidUpdate (prevProps) {
-    const { wallet, cryptoSelection, syncLedgerAccountInfo, actionsPending } = this.props
-    if (wallet.connected && !wallet.crypto[cryptoSelection] && !actionsPending.syncAccountInfo) {
+    const { wallet, cryptoSelection, syncLedgerAccountInfo, actionsPending, walletSelection } = this.props
+    if (wallet.connected && !wallet.crypto[cryptoSelection] && !actionsPending.syncAccountInfo && walletSelection === 'ledger') {
       syncLedgerAccountInfo(cryptoSelection)
     }
   }

--- a/src/containers/WalletSelectionContainer.jsx
+++ b/src/containers/WalletSelectionContainer.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import WalletSelection from '../components/WalletSelectionComponent'
-import { checkMetamaskConnection, checkLedgerNanoSConnection, loadLedgerAccountInfo } from '../actions/walletActions'
+import { checkMetamaskConnection, checkLedgerNanoSConnection, syncLedgerAccountInfo } from '../actions/walletActions'
 import { selectCrypto, selectWallet } from '../actions/formActions'
 import { createLoadingSelector, createErrorSelector } from '../selectors'
 import { goToStep } from '../actions/navigationActions'
@@ -22,6 +22,13 @@ class WalletSelectionContainer extends Component {
     }
 
     selectCrypto(cryptoType)
+  }
+
+  componentDidUpdate (prevProps) {
+    const { wallet, cryptoSelection, syncLedgerAccountInfo, actionsPending } = this.props
+    if (wallet.connected && !wallet.crypto[cryptoSelection] && !actionsPending.syncAccountInfo) {
+      syncLedgerAccountInfo(cryptoSelection)
+    }
   }
 
   render () {
@@ -46,7 +53,7 @@ class WalletSelectionContainer extends Component {
 
 const checkWalletConnectionSelector = createLoadingSelector(['CHECK_METAMASK_CONNECTION', 'CHECK_LEDGER_NANOS_CONNECTION'])
 const errorSelector = createErrorSelector(['CHECK_METAMASK_CONNECTION'])
-const loadAccountInfoSelector = createLoadingSelector(['SYNC_LEDGER_ACCOUNT_INFO', 'LOAD_LEDGER_ACCOUNT_INFO'])
+const syncAccountInfoSelector = createLoadingSelector(['SYNC_LEDGER_ACCOUNT_INFO'])
 
 const mapDispatchToProps = dispatch => {
   return {
@@ -55,7 +62,7 @@ const mapDispatchToProps = dispatch => {
     selectCrypto: (c) => dispatch(selectCrypto(c)),
     selectWallet: (w) => dispatch(selectWallet(w)),
     goToStep: (n) => dispatch(goToStep('send', n)),
-    loadLedgerAccountInfo: (cryptoType, accountIndex) => dispatch(loadLedgerAccountInfo(cryptoType, accountIndex))
+    syncLedgerAccountInfo: (c) => dispatch(syncLedgerAccountInfo(c))
   }
 }
 
@@ -66,7 +73,7 @@ const mapStateToProps = state => {
     wallet: state.walletReducer.wallet[state.formReducer.walletSelection],
     actionsPending: {
       checkWalletConnection: checkWalletConnectionSelector(state),
-      loadAccountInfo: loadAccountInfoSelector(state)
+      syncAccountInfo: syncAccountInfoSelector(state)
     },
     error: errorSelector(state)
   }

--- a/src/ledgerSigner/index.js
+++ b/src/ledgerSigner/index.js
@@ -10,10 +10,17 @@ import {
   calculateChainIdFromV,
   networkIdMap
 } from './utils'
+import BtcLedger from '@ledgerhq/hw-app-btc'
+import { address, networks } from 'bitcoinjs-lib'
+import axios from 'axios'
 
-const basePath = "44'/60'/0'/0"
+const baseEtherPath = "44'/60'/0'/0"
+const baseBtcPath = "49'/1'"
 const networkId = networkIdMap[process.env.REACT_APP_NETWORK_NAME]
 const infuraApi = `https://${process.env.REACT_APP_NETWORK_NAME}.infura.io/v3/${process.env.REACT_APP_INFURA_API_KEY}`
+const blockcypherBaseUrl = 'https://api.blockcypher.com/v1/btc/test3'
+const blockcypherToken = 'd4b651a932544a5087e1e470d4aad3bb'
+const TX_FEE_PER_BYTE = 15 // satoshi
 
 class LedgerNanoS {
   static transport
@@ -42,27 +49,45 @@ class LedgerNanoS {
   }
 
   getEthAddress = async (accountIndex) => {
-    const accountPath = basePath + `/${accountIndex}`
+    const accountPath = baseEtherPath + `/${accountIndex}`
     const ethLedger = await this.getEtherLedger()
     const result = await ethLedger.getAddress(accountPath)
     return result.address
   }
 
-  getBalance = async (accountIndex) => {
-    const address = await this.getEthAddress(accountIndex)
-    const web3 = this.getWeb3()
-    const balance = await web3.eth.getBalance(address)
+  getBalance = async (accountIndex, cryptoType) => {
+    let balance
+    switch (cryptoType) {
+      case 'ethereum':
+        const address = await this.getEthAddress(accountIndex)
+        const web3 = this.getWeb3()
+        balance = await web3.eth.getBalance(address)
+        break
+      case 'bitcoin':
+        balance = await this.getTotaBtclBalance(accountIndex)
+        break
+      default:
+        balance = 0
+    }
+
     return new BN(balance)
   }
 
-  deviceConnected = async () => {
+  getBtcLedger = async () => {
+    if (!this.btcLedger) {
+      this.btcLedger = new BtcLedger(await this.getTransport())
+    }
+    return this.btcLedger
+  }
+
+  deviceConnected = async (cryptoType) => {
     try {
       return {
         connected: true,
         accounts: [{
-          address: await this.getEthAddress(0),
+          address: cryptoType === 'bitcoin' ? null : await this.getEthAddress(0),
           balance: {
-            ethereum: await this.getBalance(0)
+            [cryptoType]: await this.getBalance(0, cryptoType)
           }
         }],
         network: networkIdMap[process.env.REACT_APP_NETWORK_NAME]
@@ -80,7 +105,7 @@ class LedgerNanoS {
    * @param {object}      options             Options of the transaction (i.e. gasLimit & gasPrice)
    */
   signSendEther = async (accountIndex, receipientAddr, amount, ...options) => {
-    const accountPath = basePath + `/${accountIndex}`
+    const accountPath = baseEtherPath + `/${accountIndex}`
     const web3 = this.getWeb3()
     const ethLedger = await this.getEtherLedger()
     const address = await this.getEthAddress(accountIndex)
@@ -155,7 +180,7 @@ class LedgerNanoS {
    * @param {[param1[, param2[, ...]]]}     params              Paramaters for the contract. The last param is a optional object contains gasPrice and gasLimit.
    */
   signSendTrasaction = async (accountIndex, contractAddress, contractAbi, methodName, ...params) => {
-    const accountPath = basePath + `/${accountIndex}`
+    const accountPath = baseEtherPath + `/${accountIndex}`
     const web3 = this.getWeb3()
     const ethLedger = await this.getEtherLedger()
     const address = await this.getEthAddress(accountIndex)
@@ -244,6 +269,143 @@ class LedgerNanoS {
     const targetContract = new web3.eth.Contract(contractAbi, contractAddress)
     const rv = await targetContract.methods[methodName](...functionParams).call()
     return rv
+  }
+
+  // BTC:
+  getTotaBtclBalance = async (accountIndex) => {
+    const btcLedger = await this.getBtcLedger()
+    let i = 0
+    let totalBalance = 0
+    while (true) {
+      const externalAddressPath = `${baseBtcPath}/${accountIndex}'/0/${i}`
+      const externalAddress = (await btcLedger.getWalletPublicKey(externalAddressPath, false, true)).bitcoinAddress
+
+      const rv = await axios.get(`${blockcypherBaseUrl}/addrs/${externalAddress}?token=${blockcypherToken}`)
+
+      const { data } = rv
+      if (data.n_tx === 0) {
+        break
+      }
+      // check change address
+      totalBalance += data.balance
+
+      const internalAddressPath = `${baseBtcPath}/${accountIndex}'/1/${i}`
+      const internalAddress = (await btcLedger.getWalletPublicKey(internalAddressPath, false, true)).bitcoinAddress
+
+      const rv2 = await axios.get(`${blockcypherBaseUrl}/addrs/${internalAddress}?token=${blockcypherToken}`)
+      totalBalance += rv2.data.balance
+
+      i += 1
+    }
+    return totalBalance
+  }
+
+  getUtxosForAccounts = async (accounts) => {
+    const utxos = await Promise.all(accounts.map(account => {
+      return axios.get(`${blockcypherBaseUrl}/addrs/${account.bitcoinAddress}?unspentOnly=true&token=${blockcypherToken}`)
+    }))
+    return accounts.map((account, i) => ({
+      account: account,
+      utxos: utxos[i].data.txrefs
+    }))
+  }
+
+  getUtxoDetails = async (txHash) => {
+    const details = await axios.get(`${blockcypherBaseUrl}/txs/${txHash}?includeHex=true&token=${blockcypherToken}`)
+    return details.data.hex
+  }
+
+  getAddressesForAmount = async (accountIndex, amount) => {
+    const btcLedger = await this.getBtcLedger()
+    let addresses = []
+    let balance = 0
+    let i = 0
+    while (balance < amount) {
+      const externalAddressPath = `${baseBtcPath}/${accountIndex}'/0/${i}`
+      const externalAddress = (await btcLedger.getWalletPublicKey(externalAddressPath, false, true))
+      const rv = await axios.get(`${blockcypherBaseUrl}/addrs/${externalAddress.bitcoinAddress}?token=${blockcypherToken}`)
+
+      const { data } = rv
+      if (data.n_tx === 0) {
+        break
+      }
+      if (data.balance !== 0) {
+        balance += data.balance
+        addresses.push({
+          ...externalAddress,
+          path: externalAddressPath
+        })
+      }
+
+      // search Change address
+      const internalAddressPath = `${baseBtcPath}/${accountIndex}'/1/${i}`
+      const internalAddress = (await btcLedger.getWalletPublicKey(internalAddressPath, false, true))
+      const rv2 = await axios.get(`${blockcypherBaseUrl}/addrs/${internalAddress.bitcoinAddress}`)
+      if (rv2.data.balance !== 0) {
+        balance += rv2.data.balance
+        addresses.push({
+          ...internalAddress,
+          path: internalAddressPath
+        })
+      }
+      i += 1
+    }
+    return addresses
+  }
+
+  createNewBtcPaymentTransaction = async (accountIndex, to, amount) => {
+    const btcLedger = await this.getBtcLedger()
+    const changeAddressPath = "49'/1'/0'/1/0"
+
+    const addresses = await this.getAddressesForAmount(accountIndex, amount)
+
+    const utxosForAccounts = await this.getUtxosForAccounts(addresses)
+
+    let inputs = []
+    let associatedKeysets = []
+    let inputValueTotal = 0
+    for (let i = 0; i < utxosForAccounts.length; i++) {
+      for (let j = 0; j < utxosForAccounts[i].utxos.length; j++) {
+        const utxo = utxosForAccounts[i].utxos[j]
+        const utxoDetails = await this.getUtxoDetails(utxo.tx_hash)
+
+        const txObj = btcLedger.splitTransaction(utxoDetails, true)
+        const input = [txObj, utxo.tx_output_n]
+        inputs.push(input)
+        associatedKeysets.push(utxosForAccounts[i].account.path)
+        inputValueTotal += utxo.value
+      }
+    }
+    let outputs = []
+    let amountBuffer = Buffer.alloc(8, 0)
+    amountBuffer.writeUIntLE(amount, 0, 8)
+    const txOutput = {
+      amount: amountBuffer,
+      script: address.toOutputScript(to, networks.testnet)
+    }
+    outputs.push(txOutput)
+
+    const change = inputValueTotal - amount - (TX_FEE_PER_BYTE * (138 + 64 * (inputs.length - 1))) // 138 bytes for 1 input, 64 bytes per additional input
+    let changeBuffer = Buffer.alloc(8, 0)
+    changeBuffer.writeUIntLE(change, 0, 8)
+    const changeAddress = (await btcLedger.getWalletPublicKey(changeAddressPath, false, true)).bitcoinAddress
+    const changeOutput = {
+      amount: changeBuffer,
+      script: address.toOutputScript(changeAddress, networks.testnet)
+    }
+    outputs.push(changeOutput)
+
+    const outputScriptHex = btcLedger.serializeTransactionOutputs({ outputs: outputs }).toString('hex')
+    const signedTxRaw = await btcLedger.createPaymentTransactionNew(inputs, associatedKeysets, changeAddressPath, outputScriptHex, undefined, undefined, true)
+
+    return signedTxRaw
+  }
+
+  broadcastBtcRawTx = async (txRaw) => {
+    const rv = await axios.post(
+      `${blockcypherBaseUrl}/txs/push?token=${blockcypherToken}`,
+      { tx: txRaw })
+    return rv.data.tx.hash
   }
 }
 

--- a/src/ledgerSigner/index.js
+++ b/src/ledgerSigner/index.js
@@ -472,6 +472,62 @@ class LedgerNanoS {
     const rv = (await axios.get(blockcypherBaseUrl)).data
     return rv.height
   }
+
+  // Function to estimate Tx size
+  // Referrenced from https://github.com/LedgerHQ/ledger-wallet-webtool/blob/094d3741527e181a626d929d56ab4a515403e4a0/src/TransactionUtils.js#L10
+  estimateTransactionSize = (
+    inputsCount,
+    outputsCount,
+    handleSegwit
+  ) => {
+    var maxNoWitness,
+      maxSize,
+      maxWitness,
+      minNoWitness,
+      minSize,
+      minWitness,
+      varintLength
+    if (inputsCount < 0xfd) {
+      varintLength = 1
+    } else if (inputsCount < 0xffff) {
+      varintLength = 3
+    } else {
+      varintLength = 5
+    }
+    if (handleSegwit) {
+      minNoWitness =
+        varintLength + 4 + 2 + 59 * inputsCount + 1 + 31 * outputsCount + 4
+      maxNoWitness =
+        varintLength + 4 + 2 + 59 * inputsCount + 1 + 33 * outputsCount + 4
+      minWitness =
+        varintLength +
+        4 +
+        2 +
+        59 * inputsCount +
+        1 +
+        31 * outputsCount +
+        4 +
+        106 * inputsCount
+      maxWitness =
+        varintLength +
+        4 +
+        2 +
+        59 * inputsCount +
+        1 +
+        33 * outputsCount +
+        4 +
+        108 * inputsCount
+      minSize = (minNoWitness * 3 + minWitness) / 4
+      maxSize = (maxNoWitness * 3 + maxWitness) / 4
+    } else {
+      minSize = varintLength + 4 + 146 * inputsCount + 1 + 31 * outputsCount + 4
+      maxSize = varintLength + 4 + 148 * inputsCount + 1 + 33 * outputsCount + 4
+    }
+    return {
+      min: minSize,
+      max: maxSize
+    }
+  }
 }
 
 export default LedgerNanoS

--- a/src/reducers/transferReducer.js
+++ b/src/reducers/transferReducer.js
@@ -9,8 +9,8 @@ const initialState = {
   // fetched from database
   transfer: null,
 
-  // gas related data
-  gasCost: null,
+  // tx related data
+  txCost: null,
 
   // transaction receipt
   receipt: null
@@ -23,10 +23,10 @@ export default function (state = initialState, action) {
         ...state,
         transfer: action.payload
       }
-    case 'GET_GAS_COST_FULFILLED':
+    case 'GET_TX_COST_FULFILLED':
       return {
         ...state,
-        gasCost: action.payload
+        txCost: action.payload
       }
     case 'TRANSACTION_HASH_RETRIEVED_FULFILLED':
       return {
@@ -43,11 +43,11 @@ export default function (state = initialState, action) {
         ...state,
         receipt: action.payload
       }
-  case 'GET_TRANSFER_HISTORY_FULFILLED':
-    return {
-      ...state,
-      transferHistory: action.payload
-    }
+    case 'GET_TRANSFER_HISTORY_FULFILLED':
+      return {
+        ...state,
+        transferHistory: action.payload
+      }
     default: // need this for default case
       return state
   }

--- a/src/reducers/walletReducer.js
+++ b/src/reducers/walletReducer.js
@@ -39,7 +39,7 @@ export default function (state = initState, action) {
       return update(state, { wallet: { metamask: { accounts: { $set: action.payload } } } })
     // ledger
     case 'CHECK_LEDGER_NANOS_CONNECTION_FULFILLED':
-      return update(state, { wallet: { ledger: { $set: action.payload } } })
+      return update(state, { wallet: { ledger: { $merge: action.payload } } })
     case 'CHECK_LEDGER_NANOS_CONNECTION_REJECTED':
       return update(state, { wallet: { ledger: { $set: {
         connected: false,
@@ -52,6 +52,10 @@ export default function (state = initState, action) {
       return update(state, { escrowWallet: { decryptedWallet: { $set: action.payload } } })
     case 'CLEAR_DECRYPTED_WALLET':
       return update(state, { escrowWallet: { decryptedWallet: { $set: null } } })
+    case 'SYNC_LEDGER_ACCOUNT_INFO_FULFILLED' || 'LOAD_LEDGER_ACCOUNT_INFO_FULFILLED':
+      return update(state, { wallet: { ledger: { accounts: { $set: [action.payload] } } } })
+    case 'LOAD_LEDGER_ACCOUNT_INFO_FULFILLED':
+      return update(state, { wallet: { ledger: { accounts: { $set: [action.payload] } } } })
     default: // need this for default case
       return state
   }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -7,20 +7,23 @@ export const cryptoSelections = [
     cryptoType: 'ethereum',
     title: 'Ethereum',
     symbol: 'ETH',
-    logo: EthereumLogo
+    logo: EthereumLogo,
+    decimals: 18
   },
   {
     cryptoType: 'dai',
     title: 'Dai',
     symbol: 'DAI',
     logo: DaiLogo,
-    address: process.env.REACT_APP_DAI_ADDRESS
+    address: process.env.REACT_APP_DAI_ADDRESS,
+    decimals: 18
   },
   {
     cryptoType: 'bitcoin',
     title: 'Bitcoin',
     symbol: 'BTC',
-    logo: BitcoinLogo
+    logo: BitcoinLogo,
+    decimals: 8
   }
 ]
 
@@ -35,4 +38,11 @@ export function getCrypto (cryptoType) {
   return cryptoSelections.find(crypto => {
     return cryptoType === crypto.cryptoType
   })
+}
+
+export function getCryptoDecimals (cryptoType) {
+  const c = cryptoSelections.find(crypto => {
+    return cryptoType === crypto.cryptoType
+  })
+  return c.decimals
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ const infuraApi = `https://${process.env.REACT_APP_NETWORK_NAME}.infura.io/v3/${
 function toHumanReadableUnit (val, decimals = 18, precision = 3) {
   let base = new BN(10).pow(new BN(decimals - precision))
   let precisionBase = new BN(10).pow(new BN(precision))
-  let rv = val.div(base)
+  let rv = (new BN(val)).div(base)
   return rv.toNumber() / precisionBase.toNumber()
 }
 
@@ -24,7 +24,7 @@ function toBasicTokenUnit (val, decimals = 18, precision = 3) {
   let base = new BN(10).pow(new BN(decimals - precision))
   let precisionBase = new BN(10).pow(new BN(precision))
   let rv = parseInt(val * precisionBase.toNumber())
-  return new BN(rv).pow(base)
+  return (new BN(rv).pow(base)).toString()
 }
 
 async function getGasCost (txObj) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,12 +29,12 @@ function toBasicTokenUnit (val, decimals = 18, precision = 3) {
 
 async function getGasCost (txObj) {
   const _web3 = new Web3(new Web3.providers.HttpProvider(infuraApi))
-  let gasPrice = await _web3.eth.getGasPrice()
+  let price = await _web3.eth.getGasPrice()
   let gas = (await _web3.eth.estimateGas(txObj)).toString()
-  let costInWei = (new BN(gasPrice).mul(new BN(gas))).toString()
-  let costInEther = _web3.utils.fromWei(costInWei, 'ether')
+  let costInBasicUnit = (new BN(price).mul(new BN(gas))).toString()
+  let costInStandardUnit = _web3.utils.fromWei(costInBasicUnit, 'ether')
 
-  return { gasPrice, gas, costInWei, costInEther }
+  return { price, gas, costInBasicUnit, costInStandardUnit }
 }
 
 /**

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -9,7 +9,7 @@ export const walletCryptoSupports = {
     { cryptoType: 'dai', disabled: false }],
   'ledger': [{ cryptoType: 'ethereum', disabled: false },
     { cryptoType: 'dai', disabled: false },
-    { cryptoType: 'bitcoin', disabled: true }]
+    { cryptoType: 'bitcoin', disabled: false }]
 }
 
 export const walletSelections = [


### PR DESCRIPTION
Resolve #165: Integrate Btc to Chainsfer
- Chainsfer can now send out btc.

Resolve #173, #178
- Get and save account info to localStorage after first connected with
ledger Nano S
- Improve transfer flow for btc on ledger. Much fast transfer process
now.

Resolve #179: Use bip38 for encryption instead of openpgp

Resolve #182, #183
- Add transaction cost estimation to Btc
- Rename gasCost to txCost, including all reference and displays.


Resolve #187, #188 
Resolve #191