### PR TITLE
Resolve #378 Drive wallet privateKey error

### DIFF
--- a/src/apis.js
+++ b/src/apis.js
@@ -62,7 +62,7 @@ async function getTransfer ({ sendingId, receivingId }) {
 async function getPrefilledAccount () {
   try {
     var rv = await axios.get(env.REACT_APP_PREFILLED_ACCOUNT_ENDPOINT)
-    return rv.data.body.privateKey
+    return rv.data.privateKey
   } catch (e) {
     console.warn(e)
     return null


### PR DESCRIPTION
- private key of prefilled account propagate error causing wrong eth
address generated